### PR TITLE
UX: remove max-width on hamburger menu

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -666,10 +666,6 @@ span.date-section {
 
 // Menu panels
 
-.hamburger-panel .menu-panel {
-  max-width: 200px;
-}
-
 .menu-container-general-links {
   hr {
     display: none;


### PR DESCRIPTION
This brings the menu back to the default width, for better support of the new hamburger/sidebar hybrid menu. 

Before:
![Screenshot 2023-05-03 at 12 28 49 PM](https://user-images.githubusercontent.com/1681963/235980025-9629cfc3-f755-4581-8f3d-fa12ac205a89.png)


After:

![Screenshot 2023-05-03 at 12 28 42 PM](https://user-images.githubusercontent.com/1681963/235980045-91b32fc5-bcaf-4a78-8823-3df6bde099f9.png)