### PR TITLE
FIX: use the core version of sidebar hover

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -847,8 +847,6 @@ div.bio {
     border-right: 1px solid var(--primary-low);
   }
 
-  --d-sidebar-highlight-color: var(--highlight-low);
-
   .sidebar-footer-container {
     background: transparent;
 


### PR DESCRIPTION
This fixes the highlight color in the sidebar when an item is selected.

**Before**
<img width="289" alt="image" src="https://github.com/discourse/minima/assets/30537603/710cfe34-5ad5-4a6b-95ee-83143c9c3765">

**After**
<img width="297" alt="image" src="https://github.com/discourse/minima/assets/30537603/709e4a58-e83c-4f82-85fb-034a78becf3b">
