### PR TITLE
DEV: Sync available outlets from core

### DIFF
--- a/desktop/header.html
+++ b/desktop/header.html
@@ -1,5 +1,5 @@
 <script type="text/x-handlebars" data-template-name="list/topic-list-item.raw">
-
+  {{~raw-plugin-outlet name="topic-list-before-columns"}}
 
   {{#if bulkSelectEnabled}}
    <td class="bulk-select">
@@ -9,7 +9,7 @@
 
     <td class='main-link clearfix' colspan="1">
       {{~raw "topic-status" topic=topic}}
-
+      {{~raw-plugin-outlet name="topic-list-before-link"}}
       <span class='link-top-line'>
         {{~raw-plugin-outlet name="topic-list-before-status"}}
         {{~topic-link topic class="raw-link raw-topic-link"}}
@@ -25,6 +25,7 @@
       <div class="link-bottom-line">
         {{~#unless hideCategory~}}
         {{~#unless topic.isPinnedUncategorized~}}
+        {{~raw-plugin-outlet name="topic-list-before-category"}}
         {{~category-link topic.category~}}
         {{/unless}}
         {{/unless}}
@@ -34,10 +35,16 @@
       {{#if expandPinned}}
       {{raw "list/topic-excerpt" topic=topic}}
       {{/if}}
+
+      {{~raw-plugin-outlet name="topic-list-main-link-bottom"}}
     </td>
+
+    {{~raw-plugin-outlet name="topic-list-after-main-link"}}
 
     {{raw "list/posts-count-column" topic=topic}}
     {{raw "list/activity-column" topic=topic class="num" tagName="td"}}
+
+    {{~raw-plugin-outlet name="topic-list-after-columns"}}
 </script>
 
 <script


### PR DESCRIPTION
This PR adds a few missing outlets [from the core](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/raw-templates/list/topic-list-item.hbr)  in `topic-list-item` to improve compatibility with plugin/theme components.
E.g. _Topic List Thumbnail_ not working with this theme, reported on meta [here](https://meta.discourse.org/t/minima-a-minimal-theme-for-discourse/108178/38?u=arkshine).

