### PR TITLE
DEV: Resolve deprecation

### DIFF
--- a/desktop/header.html
+++ b/desktop/header.html
@@ -18,7 +18,7 @@
         {{~/if}}
         {{~raw-plugin-outlet name="topic-list-after-title"}}
         {{~#if showTopicPostBadges}}
-        {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+        {{~raw "topic-post-badges" unreadPosts=topic.unread_posts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
         {{~/if}}
 
       </span>


### PR DESCRIPTION
This PR resolves the following deprecation (see [core](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/raw-templates/list/topic-list-item.hbr#L32)).

> Deprecation notice: The `displayNewPosts` property of the topic model is deprecated [deprecation id: discourse.topic.totalUnread]

